### PR TITLE
Accepts a function or an array of functions

### DIFF
--- a/method-hooks.js
+++ b/method-hooks.js
@@ -53,12 +53,18 @@ MethodHooks._wrappers = {};
  * Initializes a new hook
  * @param mapping {{}<String, [Hook]>} A place to store the mapping
  * @param methodName {String} The name of the method
- * @param hookFunction {function} The hook function
+ * @param hookFunction {function} or {array} The hook function(s)
  * @private
  */
 MethodHooks._initializeHook = function (mapping, methodName, hookFunction) {
     mapping[methodName] = mapping[methodName] || [];
-    mapping[methodName].push(hookFunction);
+
+    // Accepts a function or an array of functions
+    if (_.isArray(hookFunction)) {
+      mapping[methodName] = mapping[methodName].concat(hookFunction);
+    }else {
+      mapping[methodName].push(hookFunction)
+    }
 
     // Initialize a wrapper for the given method name. Idempotent, it will not erase existing handlers.
     var method = MethodHooks._handlers[methodName];
@@ -161,4 +167,3 @@ MethodHooks.afterMethods = function (dict) {
         MethodHooks.after(k, v);
     });
 };
-


### PR DESCRIPTION
__Problem__
We have an internal project that uses `MethodHooks.beforeMethods` as filters, We have a common `Filter` Object that contain most of our filters to be used across multiple methods, Currently If we need to pass multiple filters in the same `MethodsHook.BeforeMethods` call we will have to repeat it as the object (parameter) can't have the same key again.

```
MethodHooks.beforeMethods({
  'Calls.add': Filters.loggedIn,
  'Calls.remove': Filters.loggedIn,
});

MethodHooks.before('Calls.add', Filters.isAdmin);
```

We need to define multiple hooks per method using a readable syntax instead of repeating ourself, So the suggested solutions is passing either a function or an array of functions: 

```
MethodHooks.beforeMethods({
  'Calls.add': [Filters.loggedIn, Filters.isAdmin],
  'Calls.remove': Filters.loggedIn,
});
```

I didn't write a test yet, as I am not familiar with the testing suite, however if you accepted this proposal we will need to write the test and update the documentation. 

Let me know if you have any comments or feedback. Thanks 


